### PR TITLE
Fix no text showing in List All Tabs

### DIFF
--- a/horizontal_tabs.css
+++ b/horizontal_tabs.css
@@ -300,7 +300,7 @@ toolbar#PersonalToolbar {
     padding-left: 6px !important;
 }
 
-.toolbarbutton-text {
+#tabs-newtab-button .toolbarbutton-text {
     display: none !important;
 }
 


### PR DESCRIPTION
Specified to only hide the text for the New Tab button, instead of globally. Fixes https://github.com/greeeen-dev/Zen-Mod-Forbidden-Horizontal-Tabs/commit/1fc7fa9d8f5495c198276c87233085e3b94bea5a#r149167021

![image](https://github.com/user-attachments/assets/9128acba-3837-4bf4-b17f-17702dbc0867)

